### PR TITLE
Multiple rat mazes

### DIFF
--- a/DijkstrasRats.py
+++ b/DijkstrasRats.py
@@ -1,0 +1,117 @@
+import random
+from typing import List
+from RatInterface import Rat, MazeInfo
+from SimpleMaze import SimpleMaze, random_maze, render_graph
+from Localizer import OneDimensionalLocalizer
+
+class DijkstrasMazeInfo(MazeInfo):
+    def __init__(self, maze: List[List[int]]):
+        self.maze = maze
+        self.position = -1
+        self.direction = -1
+
+    def set_pos(self, pos: int, back: int, _rat: int):
+        self.position = pos
+        self.back = back
+
+    # Returns the current position in the maze
+    def pos(self) -> int:
+        assert self.position >= 0
+        return self.position
+
+    # Returns what would be the next position in the maze
+    # if we were to set off in the direction specified
+    # by turn (1..num_edges)
+    def peek(self, turn: int) -> int:
+        assert self.position >= 0
+        assert self.back >= 0
+        assert turn > 0
+ 
+        node = self.maze[self.position]
+        num_edges = len(node)
+        assert turn <= num_edges
+        direction = (turn + self.back) % num_edges
+
+        return node[direction]
+
+class DijkstrasRat(Rat):
+
+    def __init__(self, end: int):
+        self.end = end
+        # Initially all nodes are unvisited. We set the distance to zero
+        # for the starting node, and omit all the others, to say that
+        # they are unvisited.
+        self.distance = {0: 0}
+        self.visited = set()
+
+    # The maze asks which way we want to turn. We use Dijkstra's
+    # algorithm to determine which way to go, where the
+    # heuristic distance is the number of nodes minus the pos.
+    def turn(self, directions: int, info: MazeInfo) -> int:
+        pos = info.pos()
+        distance = self.distance[pos]
+
+        # update any unvisited nodes with the distance from this node (STEP_SIZE)
+        STEP_SIZE = 1
+        min_dir = 0
+        min_distance = 0
+        unvisited = 0
+        for dir in range(1, directions + 1):
+            node = info.peek(dir)
+            if node not in self.visited:
+                unvisited = unvisited + 1
+                edge_distance = self.update_distance(node, distance + STEP_SIZE)
+                if min_dir == 0 or edge_distance < min_distance:
+                    min_distance = edge_distance
+                    min_dir = dir
+
+        # If all nodes have been visited, this is a problem
+        if unvisited == 0:
+            raise Exception("Hit a problem. We have visited all nodes and have nowhere to go")
+
+        # If all nodes but one have been visited (presumably the node we came from,
+        # as that clearly must have been open), mark this node as visited and return
+        elif unvisited == 1:
+            self.visited.add(pos)
+
+        # show where we are and how we are progressing
+        A = ord('A')
+        print("pos=%s directions=%i unvisited=%i next=%s next_distance=%i" %
+            (chr(pos + A), directions, unvisited, chr(min_dir + A), min_distance))
+        visited_as_str = { chr(v + A) for v in self.visited }
+        distance_as_str = { chr(n + A): d for (n, d) in self.distance.items() }
+        print("  visited: %s" % visited_as_str)
+        print("  distance: %s" % distance_as_str)
+
+        # Head in the direction of the shortest unvisited node
+        assert min_dir > 0
+        return min_dir        
+
+    def update_distance(self, node: int, distance: int) -> int:
+        if node not in self.distance or self.distance[node] > distance:
+            self.distance[node] = distance
+        
+        return self.distance[node]
+
+    # Returns the distance from start to end (-1 if we never got there)
+    def distance_to_end(self) -> int:
+        if self.end not in self.distance:
+            return -1
+        else:
+            return self.distance[self.end]
+
+def test_dijkstras_rat():
+    SIZE = 6
+    maze = SimpleMaze(random_maze(0.5, OneDimensionalLocalizer(SIZE, 3)), False)
+    #print(maze)
+    render_graph(maze.maze(), "temp/dijkstras_maze")
+    rat = DijkstrasRat(SIZE)
+    info = DijkstrasMazeInfo(maze.maze())
+    MAX_ITER = 30
+    iter = maze.solve(rat, MAX_ITER, info)
+    print("test_dijkstras_rat solved in %i iterations" % iter)
+    print("  distance from start to end is %i" % rat.distance_to_end())
+    assert(iter > 0 and iter < MAX_ITER)
+
+if __name__ == "__main__":
+    test_dijkstras_rat()

--- a/MultiRatMaze.py
+++ b/MultiRatMaze.py
@@ -1,0 +1,136 @@
+from typing import List, Set, Optional, Tuple
+from random import randrange, shuffle, random
+from RatInterface import Rat, MazeInfo
+from SimpleRats import AlwaysLeftRat, RandomRat
+from SimpleMaze import random_maze, render_graph, validate_edges
+from Localizer import Localizer, NonLocalLocalizer, OneDimensionalLocalizer, TwoDimensionalOneStepLocalizer
+from graphviz import Graph
+
+# A multi-rat maze supports more than one rat, moving at different
+# speeds. The speed of each rat is defined by an integer, stating how
+# often the rat moves.
+class MultiRatMaze:
+    # Initialise with a set of edges. If fill_back_steps is true, we
+    # generate backward edges to make it an undirected graph.
+    def __init__(self, edges: List[List[int]], fill_back_steps: bool):
+        validate_edges(edges, fill_back_steps)
+        self.all_edges = edges
+
+    def __str__(self):
+        return "MultiRatMaze(%s)" % self.all_edges
+
+    def maze(self) -> List[List[int]]:
+        return self.all_edges
+
+    # Tries to solve the maze. Returns the number of iterations used.
+    # If it exceeds max_iterations, returns max_iterations + 1. The rats
+    # parameter is a list of rats and their associated speeds (one being fastest,
+    # two meaning wait every other turn etc.) Either wait for all rats,
+    # or exit as soon as the fastest rat has quit.
+    def solve(
+        self, 
+        rats: List[Tuple[Rat, int]], 
+        max_iterations: int,
+        wait_for_all: bool = False,
+        info: Optional[MazeInfo] = None) -> bool:
+
+        rat_count = len(rats)
+        if rat_count == 0:
+            raise Exception("No rats supplied")
+
+        # Always start all rats from the beginning (may want to relax this
+        # constraint)
+        pos = [0] * rat_count
+        iterations = 0
+
+        # set the last_pos such that the back path is the last in the first list
+        last = self.all_edges[0][-1]
+        last_pos = [last] * rat_count
+        #print("pos=%i last_pos=%i" % (pos, last_pos))
+
+        # keep going until the either all rats have finished or just one (or we ran
+        # out of iterations)
+        end = len(self.all_edges)
+        while not has_finished(pos, end, iterations, max_iterations, wait_for_all):
+            iterations = iterations + 1
+
+            # any rats that are not skipping this turn
+            for (i, (rat, speed)) in enumerate(rats):
+                if iterations % speed != 0:
+                    continue    # skip a turn for this rat
+
+                # find the edges from the current node
+                edges = self.all_edges[pos[i]]
+
+                # one of these edges should point back to where we came from
+                if edges.count(last_pos[i]) != 1:
+                    print("Problem: no edge from %i to %i" % (pos[i], last_pos[i]))
+                back = edges.index(last_pos[i])
+
+                # supply maze info for rats that need it
+                if info:
+                    info.set_pos(pos[i], back, i)
+
+                # get the rat to choose a direction
+                num_edges = len(edges)
+                turn = rat.turn(num_edges, info)
+                if (turn >= num_edges) or (turn < 0):
+                    raise Exception("Rat turn out of range")
+                
+                # going in some direction
+                direction = (turn + back) % num_edges
+                last_pos[i] = pos[i]
+                pos[i] = edges[direction]
+                #print("pos=%i last_pos=%i" % (pos, last_pos))
+
+        # hit the end, or failed with an iteration count that is too high
+        # (technically we should worry about the case where we hit max
+        # iterations with a valid exit, but this is unlikely and does not
+        # matter much).
+        return iterations            
+
+def has_finished(pos: List[int], end: int, iterations: int, max_iterations: int, wait_for_all: bool) -> bool:
+    if iterations > max_iterations:
+        return True
+    
+    if wait_for_all:
+        return all(p == end for p in pos)
+    else:
+        return end in pos
+
+def test_multiple_left_rats():
+    rat = AlwaysLeftRat()   # content-less rat, so only need one
+    rats = [(rat, 2), (rat, 3)]
+    maze = MultiRatMaze([[1, 3], [2], [3, 0]], True)
+    MAX_ITER = 10
+    iter = maze.solve(rats, MAX_ITER)
+    print("test_left_multi_rats solved in %i iterations" % iter)
+    assert(iter > 0 and iter <= MAX_ITER)
+
+def test_big_multimaze():
+    rat = RandomRat()   # content-less rat, so only need one
+    rats = [(rat, 2), (rat, 3)]
+    maze = MultiRatMaze([[5, 3], [6], [5, 3, 17, 14, 13, 20], 
+        [2, 0, 4, 14, 13, 5, 17, 12], [7, 3], [0, 14, 9, 2, 6, 3],
+        [5, 13, 1], [8, 4, 19, 10], [14, 7], [14, 5, 17], [7, 13], 
+        [15, 16], [3, 15], [6, 17, 10, 3, 16, 2], [5, 9, 2, 8, 3, 19], 
+        [12, 11, 18], [11, 13], [13, 2, 9, 3], [15], [14, 7]], False)
+    MAX_ITER = 1000
+    iter = maze.solve(rats, MAX_ITER)
+    print("test_big_maze solved in %i iterations" % iter)
+    assert(iter > 0 and iter < MAX_ITER)
+
+def test_random_1d_multimaze():
+    maze = MultiRatMaze(random_maze(0.5, OneDimensionalLocalizer(25, 5)), False)
+    render_graph(maze.maze(), "temp/random_1d_multimaze")
+    rat = RandomRat()
+    rats = [(rat, 2), (rat, 3)]
+    MAX_ITER = 1000
+    iter = maze.solve(rats, MAX_ITER)
+    print("test_random_1d_multimaze solved in %i iterations" % iter)
+    assert(iter > 0 and iter < MAX_ITER)
+
+if __name__ == "__main__":
+    test_multiple_left_rats()
+    test_big_multimaze()
+    test_random_1d_multimaze()

--- a/PairedRats.py
+++ b/PairedRats.py
@@ -1,0 +1,62 @@
+import random
+from RatInterface import Rat, MazeInfo
+from MultiRatMaze import MultiRatMaze
+from SimpleMaze import random_maze, render_graph
+from Localizer import OneDimensionalLocalizer
+
+# The only thing that paired rats know about is that they see another rat
+# at the same location as themselves
+class PairedRatMazeInfo(MazeInfo):
+    def __init__(self):
+        self.positions = [-1] * 2
+        self.hit_rat = [False] * 2
+        self.rat = 0
+
+    def set_pos(self, pos: int, back: int, rat: int):
+        if rat > 1:
+            raise Exception("Only two rats allowed with PairedRat")
+        self.rat = rat
+        self.positions[rat] = pos
+        
+        # have we landed on the other rat?
+        if self.positions[0] == self.positions[1]:
+            self.hit_rat = [True] * 2
+
+    # Tests whether the current rat has hit another rat. Always resets
+    # the state back to unhit, so hits only count once per rat.    
+    def has_hit_rat(self) -> bool:
+        hit = self.hit_rat[self.rat]
+        self.hit_rat[self.rat] = False
+        return hit
+
+class PairedAlwaysRat(Rat):
+
+    # The maze asks which way we want to turn. We always turn in
+    # the left-most direction, which is 1 unless we can only go
+    # backwards. The exception to this rule is when we run into
+    # another rat, in which case we assume we must be in a loop
+    # and both rats have to reverse back the way they came.
+    def turn(self, directions: int, info: MazeInfo) -> int:
+        
+        # if we hit a rat, go back the way we came
+        if info.has_hit_rat():
+            return 0
+        
+        # otherwise behave like a standard always-left rat
+        if directions > 1:
+            return 1
+        else:
+            return 0    # dead-end or pit
+
+def test_paired_rats():
+    maze = MultiRatMaze(random_maze(0.5, OneDimensionalLocalizer(25, 5)), False)
+    render_graph(maze.maze(), "temp/paired")
+    rat = PairedAlwaysRat()     # stateless rat, so we only need one
+    rats = [(rat, 2), (rat, 3)]
+    MAX_ITER = 1000
+    iter = maze.solve(rats, MAX_ITER, False, PairedRatMazeInfo())
+    print("test_paired_rats solved in %i iterations" % iter)
+    assert(iter > 0 and iter < MAX_ITER)
+
+if __name__ == "__main__":
+    test_paired_rats()

--- a/RatInterface.py
+++ b/RatInterface.py
@@ -4,8 +4,9 @@ class MazeInfo(ABC):
     # Allows the maze to set the position and direction of the
     # current node.
     @abstractmethod
-    def set_pos(self, pos: int, back: int):
+    def set_pos(self, pos: int, back: int, rat: int):
         pass
+
 
 class Rat(ABC):
 

--- a/SimpleMaze.py
+++ b/SimpleMaze.py
@@ -14,37 +14,7 @@ class SimpleMaze:
     # Initialise with a set of edges. If fill_back_steps is true, we
     # generate backward edges to make it an undirected graph.
     def __init__(self, edges: List[List[int]], fill_back_steps: bool):
-
-        # validate and optionally fill back steps
-        end = len(edges)
-        if end < 1:
-            raise Exception("Must be at least one node")
-
-        has_end = False
-        edge_from = 0
-        for node in edges:
-            if len(set(node)) != len(node):
-                raise Exception("Must not have duplicate edges")
-            for edge_to in node:
-                if edge_to == end:
-                    has_end = True  # OK to have multiple routes to end
-                elif edge_to > end:
-                    raise Exception("Edge out of range")
-                elif edge_to == edge_from:
-                    raise Exception("Not allowed to have edges to self")
-                elif fill_back_steps:
-                    # make sure we have a return edge matching this
-                    ensure_edge(edges, edge_to, edge_from)
-            
-            # next node
-            edge_from = edge_from + 1
-
-        # We validate that at least one node has an edge leading to the
-        # exit. However, we do not currently check that there is a clear
-        # path to any such node.
-        if not has_end:
-            raise Exception("No edge to the end node")
-
+        validate_edges(edges, fill_back_steps)
         self.all_edges = edges
 
     def __str__(self):
@@ -77,9 +47,10 @@ class SimpleMaze:
                 print("Problem: no edge from %i to %i" % (pos, last_pos))
             back = edges.index(last_pos)
 
-            # supply maze info for rats that need it
+            # supply maze info for rats that need it. There is only one rat,
+            # so supply rat number zero
             if info:
-                info.set_pos(pos, back)
+                info.set_pos(pos, back, 0)
 
             # get the rat to choose a direction
             num_edges = len(edges)
@@ -99,6 +70,37 @@ class SimpleMaze:
         # iterations with a valid exit, but this is unlikely and does not
         # matter much).
         return iterations            
+
+# validate and optionally fill back steps
+def validate_edges(edges: List[List[int]], fill_back_steps: bool):
+    end = len(edges)
+    if end < 1:
+        raise Exception("Must be at least one node")
+
+    has_end = False
+    edge_from = 0
+    for node in edges:
+        if len(set(node)) != len(node):
+            raise Exception("Must not have duplicate edges")
+        for edge_to in node:
+            if edge_to == end:
+                has_end = True  # OK to have multiple routes to end
+            elif edge_to > end:
+                raise Exception("Edge out of range")
+            elif edge_to == edge_from:
+                raise Exception("Not allowed to have edges to self")
+            elif fill_back_steps:
+                # make sure we have a return edge matching this
+                ensure_edge(edges, edge_to, edge_from)
+        
+        # next node
+        edge_from = edge_from + 1
+
+    # We validate that at least one node has an edge leading to the
+    # exit. However, we do not currently check that there is a clear
+    # path to any such node.
+    if not has_end:
+        raise Exception("No edge to the end node")
 
 # Validates that we have an edge (and if necessary inserts one)
 def ensure_edge(maze: List[List[int]], edge_from: int, edge_to: int):

--- a/Tremaux.py
+++ b/Tremaux.py
@@ -11,7 +11,7 @@ class TremauxMazeInfo(MazeInfo):
         self.back = -1
         self.started = False
 
-    def set_pos(self, pos: int, back: int):
+    def set_pos(self, pos: int, back: int, _rat: int):
         self.position = pos
         self.back = back
 


### PR DESCRIPTION
The interesting example here is in PairedRat. A single rat that always turns left can get stuck in loops. However, if we introduce two rats with the following rule:

1. If we cannot see the other rat, act like a standard always-left rat
2. If we can see the other rat, go back the way we came (the other rat also reverses)

This seems to solve all mazes, including those with loops. I leave it as an exercise to prove why this is the case.